### PR TITLE
Added PVC for storing MMIO files

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -772,9 +772,8 @@ components:
             extraMetadata:
               '@type': med:Diagnoses
               med:hasDiagnosis:
-                med:code:
-                  operation: contains
-                  operationValue: I10
+                '@type': med:Diagnosis
+                med:code: I10
     Dataset:
       properties: {}
       additionalProperties: true

--- a/server/README.md
+++ b/server/README.md
@@ -91,6 +91,7 @@ Requirements:
 6. To delete the deployment:
     ```bash
     helm delete catalog
+    kubectl delete pvc catalog-ds-catalog-uploads
     ```
 
 ### Production

--- a/server/app/rest_api/examples.py
+++ b/server/app/rest_api/examples.py
@@ -243,12 +243,7 @@ catalog_filters_example: dict[str, Any] = {
             "dcat:dataset": {
                 "extraMetadata": {
                     "@type": "med:Diagnoses",
-                    "med:hasDiagnosis": {
-                        "med:code": {
-                            "operationValue": "I10",
-                            "operation": "contains",
-                        }
-                    },
+                    "med:hasDiagnosis": {"@type": "med:Diagnosis", "med:code": "I10"},
                 }
             }
         }

--- a/server/charts/server/templates/deployment.yaml
+++ b/server/charts/server/templates/deployment.yaml
@@ -46,6 +46,13 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
             {{- include "app.commonEnv" . | nindent 12 }}
+          volumeMounts:
+            - name: uploads
+              mountPath: {{ .Values.persistence.mountPath }}
+      volumes:
+        - name: uploads
+          persistentVolumeClaim:
+            claimName: {{ include "app.fullname" . }}-uploads
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/server/charts/server/templates/pvc.yaml
+++ b/server/charts/server/templates/pvc.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "app.fullname" . }}-uploads
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 2 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/server/charts/server/values.yaml
+++ b/server/charts/server/values.yaml
@@ -37,6 +37,14 @@ readinessProbe:
     path: /health-check/
     port: http
 
+persistence:
+  enabled: true
+  accessModes:
+    - ReadWriteOnce
+  size: 1Gi
+  storageClass: ""
+  mountPath: /code/uploads
+
 catalog:
   title: Catalog
   description: My Local Catalog


### PR DESCRIPTION
### Description
Added PVC for storing MMIO files during redeployment.

### Related Story
* [Create an endpoint to upload the MMIO file](https://www.notion.so/hirodevops/Create-an-endpoint-to-upload-the-MMIO-file-1d6694b0acd880d9ab9adbc5c594f7e9)

### Changes
* Added PVC to the Helm Chart
* Fixed an example